### PR TITLE
Change casing of $_GET keys to improve compatibility with VS14

### DIFF
--- a/inc/core.php
+++ b/inc/core.php
@@ -16,3 +16,6 @@ function api_error($code, $message) {
 set_exception_handler(function($exception) {
 	api_error('500', $exception->getMessage());
 });
+
+// Make $_GET keys lower-case for improved NuGet client compatibility.
+$_GET = array_change_key_case($_GET, CASE_LOWER);

--- a/public/download.php
+++ b/public/download.php
@@ -1,5 +1,8 @@
 <?php
 require(__DIR__ . '/../inc/core.php');
+
+$_GET = array_change_key_case($_GET, CASE_LOWER);
+
 $id = $_GET['id'];
 $version = $_GET['version'];
 

--- a/public/download.php
+++ b/public/download.php
@@ -1,8 +1,6 @@
 <?php
 require(__DIR__ . '/../inc/core.php');
 
-$_GET = array_change_key_case($_GET, CASE_LOWER);
-
 $id = $_GET['id'];
 $version = $_GET['version'];
 

--- a/public/findByID.php
+++ b/public/findByID.php
@@ -2,8 +2,6 @@
 require(__DIR__ . '/../inc/core.php');
 require(__DIR__ . '/../inc/feedwriter.php');
 
-$_GET = array_change_key_case($_GET, CASE_LOWER);
-
 $id = trim($_GET['id'], '\'');
 $version = null;
 if (!empty($_GET['version'])) {

--- a/public/findByID.php
+++ b/public/findByID.php
@@ -2,6 +2,8 @@
 require(__DIR__ . '/../inc/core.php');
 require(__DIR__ . '/../inc/feedwriter.php');
 
+$_GET = array_change_key_case($_GET, CASE_LOWER);
+
 $id = trim($_GET['id'], '\'');
 $version = null;
 if (!empty($_GET['version'])) {

--- a/public/search.php
+++ b/public/search.php
@@ -2,8 +2,6 @@
 require(__DIR__ . '/../inc/core.php');
 require(__DIR__ . '/../inc/feedwriter.php');
 
-$_GET = array_change_key_case($_GET, CASE_LOWER);
-
 // TODO: Pagination
 $results = DB::searchPackages([
 	'includePrerelease' => !empty($_GET['includeprerelease']),

--- a/public/search.php
+++ b/public/search.php
@@ -2,12 +2,14 @@
 require(__DIR__ . '/../inc/core.php');
 require(__DIR__ . '/../inc/feedwriter.php');
 
+$_GET = array_change_key_case($_GET, CASE_LOWER);
+
 // TODO: Pagination
 $results = DB::searchPackages([
-	'includePrerelease' => !empty($_GET['includePrerelease']),
+	'includePrerelease' => !empty($_GET['includeprerelease']),
 	'orderBy' => isset($_GET['$orderby']) ? $_GET['$orderby'] : '',
 	'filter' => isset($_GET['$filter']) ? $_GET['$filter'] : '',
-	'searchQuery' => isset($_GET['searchTerm']) ? trim($_GET['searchTerm'], '\'') : '',
+	'searchQuery' => isset($_GET['searchterm']) ? trim($_GET['searchterm'], '\'') : '',
 ]);
 $feed = new FeedWriter('Search');
 $feed->writeToOutput($results);

--- a/public/updates.php
+++ b/public/updates.php
@@ -2,8 +2,6 @@
 require(__DIR__ . '/../inc/core.php');
 require(__DIR__ . '/../inc/feedwriter.php');
 
-$_GET = array_change_key_case($_GET, CASE_LOWER);
-
 $package_ids = explode('|', trim($_GET['packageids'], '\''));
 $versions = explode('|', trim($_GET['versions'], '\''));
 $package_to_version = array_combine($package_ids, $versions);

--- a/public/updates.php
+++ b/public/updates.php
@@ -2,12 +2,14 @@
 require(__DIR__ . '/../inc/core.php');
 require(__DIR__ . '/../inc/feedwriter.php');
 
-$package_ids = explode('|', trim($_GET['packageIds'], '\''));
+$_GET = array_change_key_case($_GET, CASE_LOWER);
+
+$package_ids = explode('|', trim($_GET['packageids'], '\''));
 $versions = explode('|', trim($_GET['versions'], '\''));
 $package_to_version = array_combine($package_ids, $versions);
 
 $results = DB::packageUpdates([
-	'includePrerelease' => !empty($_GET['includePrerelease']),
+	'includePrerelease' => !empty($_GET['includeprerelease']),
 	'packages' => $package_to_version,
 ]);
 $feed = new FeedWriter('GetUpdates');


### PR DESCRIPTION
This is necessary because Visual Studio 14 makes requests such as:
    GET /FindPackagesById()?Id='X.Y.Z' HTTP/1.1

Rather than the expected:
    GET /FindPackagesById()?id='X.Y.Z' HTTP/1.1

Before: http://puu.sh/dkaRB/2618631e63.png
After: http://puu.sh/dkaTa/1b0623abf2.png