### PR TITLE
Escape IconUrl value before we output it.

### DIFF
--- a/inc/feedwriter.php
+++ b/inc/feedwriter.php
@@ -93,7 +93,7 @@ class FeedWriter {
             'Copyright' => $row['Copyright'],
             'Created' => static::renderMetaDate($row['Created']),
             'Dependencies' => $this->renderDependencies($row['Dependencies']),
-            'Description' => $row['Description'],
+            'Description' => htmlspecialchars($row['Description']),
             'DownloadCount' => ['value' => $row['DownloadCount'], 'type' => 'Edm.Int32'],
             'GalleryDetailsUrl' => $this->baseURL . 'details/' . $row['PackageId'] . '/' . $row['Version'],
             'IconUrl' => htmlspecialchars($row['IconUrl']),

--- a/inc/feedwriter.php
+++ b/inc/feedwriter.php
@@ -96,7 +96,7 @@ class FeedWriter {
             'Description' => $row['Description'],
             'DownloadCount' => ['value' => $row['DownloadCount'], 'type' => 'Edm.Int32'],
             'GalleryDetailsUrl' => $this->baseURL . 'details/' . $row['PackageId'] . '/' . $row['Version'],
-            'IconUrl' => $row['IconUrl'],
+            'IconUrl' => htmlspecialchars($row['IconUrl']),
             'IsLatestVersion' => static::renderMetaBoolean($row['LatestVersion'] === $row['Version']),
             'IsAbsoluteLatestVersion' => static::renderMetaBoolean($row['LatestVersion'] === $row['Version']),
             'IsPrerelease' => static::renderMetaBoolean($row['IsPrerelease']),


### PR DESCRIPTION
Simple-nuget-server threw an unterminated entity reference error when I pushed xunit 1.9.2 to our NuGet repository. The xunit package has IconUrl "http://download.codeplex.com/Download?ProjectName=xunit&DownloadId=365445", which needs to be escaped to "http://download.codeplex.com/Download?ProjectName=xunit&amp;DownloadId=365445".

Moving the string escape to the $entry->addChild invocation at addMeta probably makes more sense, though I haven't tested that.