### PR TITLE
Added Functionality to Delete Package Versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Simple NuGet Server
-===================
+=================== 
 
 A very simple NuGet server for my personal use, similar to
 [NuGet.Server](https://www.nuget.org/packages/NuGet.Server) but in PHP. Designed
@@ -12,8 +12,9 @@ Features
  - Pushing via NuGet command line (NuGet.exe)
  - Simple set up
  - Stores data in SQLite or MySQL database
- - Uses a single API key (so not suitable for scenarios where multiple users
-   need to be able to push packages)
+ - Uses a single API key (so not suitable for scenarios where multiple users need to be able to push packages)
+ - Delete a package version (this feature comes handy while testing package deployment)
+
 
 Setup
 =====
@@ -28,18 +29,27 @@ git clone https://github.com/Daniel15/simple-nuget-server.git
 chown www-data:www-data db packagefiles
 chmod 0770 db packagefiles
 ```
+3 - This solution requires PHP to have support for sqlite. Proceed to install as follows if needed
+```bash
+# check if pp5-sqlite is installed
+dpkg --get-selections | grep php5-sqlite
+# install package if not found
+apt-get install php5-sqlite
+```
 
-2 - Copy nginx.conf.example to /etc/nginx/sites-available and modify it for your environment:
- - Change `example.com` to your domain name
- - Change `/var/www/simple-nuget-server/` to the checkout directory
- - Change "hhvm" to the name of a PHP upstream in your Nginx config. This can be regular PHP 5.4+ or HHVM.
+2 - Copy nginx.conf.example to /etc/nginx/sites-available/nuget and modify it for your environment:
+ - Change `example.com` to your domain name.  In my environment I am using `homenuget.com`. Remember to add this entry to the client host file if needed
+ - Root must point to `/var/www/simple-nuget-server/public/`. Do not change this entry
+ - Change "hhvm" to the name of a PHP upstream in your Nginx config. This can be regular PHP 5.4+ or HHVM.  This entry needs to be changed for the \.php$ and /index.php locations
  - If hosting as part of another site, prefix everything with a subdirectory and combine the config with your existing site's config (see ReactJS.NET config at the end of this comment)
 
 3 - Edit `inc/config.php` and change `ChangeThisKey` to a randomly-generated string
 
 4 - Enable the site (if creating a new site)
 ```bash
+# create link to folder to enable site
 ln -s /etc/nginx/sites-available/nuget /etc/nginx/sites-enabled/nuget
+# reload nginx
 /etc/init.d/nginx reload
 ```
 
@@ -53,6 +63,17 @@ nuget.exe push Foo.nupkg -Source http://example.com/
 Examples
 ========
 [ReactJS.NET](http://reactjs.net/) repository at at http://reactjs.net/packages/. You can see its Nginx configuration at https://github.com/reactjs/React.NET/blob/master/site/nginx.conf
+
+Links
+========
+[Nuget Command Line (windows)](https://docs.nuget.org/consume/command-line-reference) 
+
+Versions
+========
+- 1.0.1
+Includes ability to delete versions of a package and update the package to the next available version. Package record and root directory is deleted when no more version are available
+- 1.0.0
+Push, Search, List and download capabilities
 
 Licence
 =======

--- a/inc/db.php
+++ b/inc/db.php
@@ -246,6 +246,69 @@ class DB {
 		$stmt->execute($params);
 	}
 
+
+	// Delete a package
+    public static function deletePackage($id) {
+        	$stmt = static::$conn->prepare('
+                        DELETE FROM packages
+                        WHERE PackageId = :id
+               ');
+                $stmt->execute([
+				':id' => $id,]);
+        }
+
+
+	// Delete a particular package version
+     public static function deleteVersion($id, $version) {
+        	$stmt = static::$conn->prepare('
+			DELETE FROM versions
+			WHERE PackageId = :id and  Version = :version
+		');
+		$stmt->execute([
+				':id' => $id,
+				':version' => $version,]);
+        }
+
+
+	// Check if a package has any versions on record
+	public static function hasVersions($id) {
+		$stmt = static::$conn->prepare('
+			SELECT COUNT(1)
+			FROM versions
+			WHERE PackageId = :id
+		');
+		$stmt->execute([
+			':id' => $id,
+		]);
+		return $stmt->fetchColumn() > 0;
+		
+	}
+
+	// Get the top version for a package
+	public static function getTopVersion($id) {
+
+		// Get all versions for a package in descending order
+		$stmt = static::$conn->prepare('
+			SELECT
+			        versions.Version,
+				versions.Title
+			FROM versions
+			WHERE versions.PackageId = :id
+			ORDER by versions.Version desc
+			');
+	     	
+		$stmt->execute([
+			':id' => $id,
+		]);
+		return $stmt->fetch(PDO::FETCH_ASSOC);
+	}
+
+
+
+
+
+
+
 	public static function insertVersion($params) {
 		$params[':Created'] = time();
 		$params[':Dependencies'] = json_encode($params[':Dependencies']);

--- a/nginx.conf.example
+++ b/nginx.conf.example
@@ -4,6 +4,8 @@ server {
 	server_name example.com;
 	root /var/www/simple-nuget-server/public/;
 
+	error_log /var/log/nginx/example.com_error.com.log error;
+	access_log /var/log/nginx/example.com_access.log error;
 	rewrite ^/$ /index.php;
 	rewrite ^/\$metadata$ /metadata.xml;
 	rewrite ^/Search\(\)/\$count$ /count.php;
@@ -19,12 +21,17 @@ server {
 	location ~ \.php$ {
 		include fastcgi_params;
 		fastcgi_pass hhvm;
+		#sample entry - replace hhvm based on your nginx settings
+		#fastcgi_pass unix:/var/run/php5-fpm.sock;
 	}
 
 	location = /index.php {
-		dav_methods PUT;
+		dav_methods PUT DELETE;
+		dav_access user:rw group:rw all:r;
 		include fastcgi_params;
 		fastcgi_pass hhvm;
+		#sample entry - replace hhvm based on your nginx settings
+		#fastcgi_pass unix:/var/run/php5-fpm.sock;		
 
 		# PHP doesn't parse request body for PUT requests, so fake a POST.
 		fastcgi_param REQUEST_METHOD POST;
@@ -36,4 +43,7 @@ server {
 		internal;
 		root /var/www/simple-nuget-server/;
 	}
+	
+	# sample entry for a stand alone server
+	# listen 192.168.1.10:80 default_server ipv6only=off;
 }

--- a/public/delete.php
+++ b/public/delete.php
@@ -1,0 +1,67 @@
+<?php
+require(__DIR__ . '/../inc/core.php');
+$url = $_SERVER['REQUEST_URI'];
+$url_parts = explode("/", $url);
+
+
+if (empty($_SERVER['HTTP_X_NUGET_APIKEY']) || $_SERVER['HTTP_X_NUGET_APIKEY'] != Config::$apiKey) {
+	api_error('403', 'Invalid API key from Omar');
+}
+
+if (count($url_parts)!= 6 ) {
+	api_error('400','Invalid URL format ['.$url.']');
+}
+
+$id = $url_parts[4];
+$version = $url_parts[5];
+
+// Validate the package is in the database
+if (!DB::validateIdAndVersion($id, $version)) {
+    api_error('400', 'Invalid ID or version');
+}
+
+
+// Setup directory place
+$dir =  Config::$packageDir . $id . DIRECTORY_SEPARATOR;
+$path = $dir . $version . '.nupkg';
+
+// Delete package version 
+if ( file_exists($path)) {
+	//api_error('403',$path);
+	unlink($path);
+}
+
+// Delete root directory if it is empty (last version deleted)
+if ( file_exists($dir) ) {
+	$fi = new FilesystemIterator($dir,FilesystemIterator::SKIP_DOTS);
+	if (iterator_count($fi) == 0) {
+		rmdir($dir);
+	}
+}
+
+// Delete the requested version
+DB::deleteVersion($id,$version);
+
+if (!DB::hasVersions($id)) {
+	// Delete record - no more versions exist
+	DB::deletePackage($id);
+}
+else {
+	// Provide a new version for the package - the top one was deleted
+	$row = DB::getTopVersion($id);
+	if ($row) {
+		DB::insertOrUpdatePackage([
+			':id' => $id,
+			':title' => $row['Title'],
+			':version' => $row['Version']
+		]);
+	}
+	else {
+		DB::deletePackage($id);	
+	}
+}
+
+
+
+//All done!
+header('HTTP:/1.1 200 OK');

--- a/public/index.php
+++ b/public/index.php
@@ -5,10 +5,25 @@ $is_put = $_SERVER['REQUEST_METHOD'] === 'PUT' ||
 		!empty($_SERVER['HTTP_X_METHOD_OVERRIDE']) &&
 		$_SERVER['HTTP_X_METHOD_OVERRIDE'] === 'PUT'
 	);
+
+// DELETE request need to be redirected to delete.php
+$is_delete = $_SERVER['REQUEST_METHOD'] === 'DELETE' ||
+	(
+		!empty($_SERVER['HTTP_X_METHOD_OVERRIDE']) &&
+		$_SERVER['HTTP_X_METHOD_OVERRIDE'] === 'DELETE'
+	);
+
 if ($is_put) {
 	require(__DIR__ . '/push.php');
 	die();
 }
+
+if ($is_delete) {
+	require(__DIR__.'/delete.php');
+	die();
+}
+
+
 
 header('Content-Type: text/xml; charset=utf-8');
 $base_url = 'http://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['SCRIPT_NAME']);


### PR DESCRIPTION
The deletion of packages is helpful while testing package deployment.  This functionality has the following features:
- Version deleted is removed from the database and from the package directory
- Package version is downgraded to highest available version (nuget -list shows next available version)
- Package record and directory are deleted once there are no more versions
- Tested on openmediavault (debian 7 with nginx) and nuget.exe