### PR TITLE
Nuget package manager fixes

### DIFF
--- a/nginx.conf.example
+++ b/nginx.conf.example
@@ -17,6 +17,7 @@ server {
 	rewrite ^/([^/]+)/([^/]+)$ /delete.php?id=$1&version=$2;
 
 	# NuGet.exe adds /api/v2/ to URL when the server is at the root
+	rewrite ^/api/v2/package$ /index.php;
 	rewrite ^/api/v2/package/$ /index.php;
 	rewrite ^/api/v2/package/([^/]+)/([^/]+)$ /delete.php?id=$1&version=$2;
 

--- a/public/push.php
+++ b/public/push.php
@@ -3,11 +3,17 @@ require_once(__DIR__ . '/../inc/core.php');
 
 require_auth();
 
-if (empty($_FILES['package'])) {
+if (count($_FILES)==0)
+{
 	api_error('400', 'No package file');
 }
 
-$upload_filename = $_FILES['package']['tmp_name'];
+$upload_filename = "";
+foreach ($_FILES as $value)
+{
+        $upload_filename=$value['tmp_name'];
+        break;
+}
 // Try to find NuSpec file
 $package_zip = new ZipArchive();
 $package_zip->open($upload_filename);
@@ -40,7 +46,7 @@ if (DB::validateIdAndVersion($id, $version)) {
 }
 
 $hash = base64_encode(hash_file('sha512', $upload_filename, true));
-$filesize = filesize($_FILES['package']['tmp_name']);
+$filesize = filesize($upload_filename);
 $dependencies = [];
 
 


### PR DESCRIPTION
Nuget package manager version 3.9.0.0 don't work with base configuration.

1. This program are sending query without slash. I was added string in nginx.conf.example
2. File name in put query send file with name as package name. Script is working with the first filename.