### PR TITLE
ReleaseNotes should be escaped too in feedwriter.php

### DIFF
--- a/inc/feedwriter.php
+++ b/inc/feedwriter.php
@@ -107,7 +107,7 @@ class FeedWriter {
 			'PackageSize' => ['value' => $row['PackageSize'], 'type' => 'Edm.Int64'],
 			'ProjectUrl' => $row['ProjectUrl'],
 			'ReportAbuseUrl' => '',
-			'ReleaseNotes' => $row['ReleaseNotes'],
+			'ReleaseNotes' => htmlspecialchars($row['ReleaseNotes']),
 			'RequireLicenseAcceptance' => static::renderMetaBoolean($row['RequireLicenseAcceptance']),
 			'Summary' => null,
 			'Tags' => $row['Tags'],


### PR DESCRIPTION
For example Moq package (that I've put in feed) has long Release notes with special characters. That breaks feed search.