### PR TITLE
Remove the additional slash.

### DIFF
--- a/inc/feedwriter.php
+++ b/inc/feedwriter.php
@@ -8,7 +8,7 @@ class FeedWriter {
 		$this->baseURL =
 			url_scheme() .
 			$_SERVER['SERVER_NAME'] .
-			dirname($_SERVER['REQUEST_URI']);
+			rtrim(dirname($_SERVER['REQUEST_URI']), '/') . '/';
 	}
 
 	public function write(array $results) {

--- a/inc/feedwriter.php
+++ b/inc/feedwriter.php
@@ -8,7 +8,7 @@ class FeedWriter {
 		$this->baseURL =
 			url_scheme() .
 			$_SERVER['SERVER_NAME'] .
-			dirname($_SERVER['REQUEST_URI']) . '/';
+			dirname($_SERVER['REQUEST_URI']);
 	}
 
 	public function write(array $results) {


### PR DESCRIPTION
The base should be 'https://nuget.xxxxxxxxxxxxxx.com/' and not 'http://nuget.xxxxxxxxxxxxxx.com//.'
It seems to be the double slash at the end that is breaking the request.

Nuget tries to resolve it to
Resolved actions to install package 'xxxxxxxxxx.5.1.0.47-develop'
`GET http://nuget.xxxxxxxxxxxxxx.com//download/xxxxxxxxxx/5.1.0.47-develop`

When I call that directly I only a response Only DELETEs allowed here. If I remove the double slash it works.
