### PR TITLE
Allow the server to run on any port.

### DIFF
--- a/inc/feedwriter.php
+++ b/inc/feedwriter.php
@@ -7,7 +7,7 @@ class FeedWriter {
 		$this->feedID = $id;
 		$this->baseURL =
 			url_scheme() .
-			$_SERVER['SERVER_NAME'] .
+			$_SERVER['SERVER_NAME'] . ':' . $_SERVER['SERVER_PORT'] .
 			rtrim(dirname($_SERVER['REQUEST_URI']), '/') . '/';
 	}
 


### PR DESCRIPTION
If the server runs on anything but default HTTP and HTTPS ports, it works fine for browsing packages and pushing new ones, but nuget fails to download any.

Just include the server port in baseURL and then it works fine.