### PR TITLE
Create a framework entry even if it has no dependencies

### DIFF
--- a/public/push.php
+++ b/public/push.php
@@ -59,12 +59,21 @@ if ($nuspec->metadata->dependencies) {
 	if ($nuspec->metadata->dependencies->group) {
 		// Dependencies that are specific to a particular framework
 		foreach ($nuspec->metadata->dependencies->group as $group) {
-			foreach ($group->dependency as $dependency) {
+			if (!$group->dependency) {
+				// Group doesn't have any dependencies but we still need to save the framework
 				$dependencies[] = [
 					'framework' => (string)$group['targetFramework'],
-					'id' => (string)$dependency['id'],
-					'version' => (string)$dependency['version']
+					'id' => '',
+					'version' => ''
 				];
+			} else {
+				foreach ($group->dependency as $dependency) {
+					$dependencies[] = [
+						'framework' => (string)$group['targetFramework'],
+						'id' => (string)$dependency['id'],
+						'version' => (string)$dependency['version']
+					];
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Currently frameworks without dependencies are not saved to the database and don't display in Visual Studio (#33).

This change adds a framework entry without dependencies if required.