### PR TITLE
Add pagination to the searchPackages function

### DIFF
--- a/public/search.php
+++ b/public/search.php
@@ -2,12 +2,13 @@
 require(__DIR__ . '/../inc/core.php');
 require(__DIR__ . '/../inc/feedwriter.php');
 
-// TODO: Pagination
 $results = DB::searchPackages([
 	'includePrerelease' => !empty($_GET['includeprerelease']),
 	'orderBy' => isset($_GET['$orderby']) ? $_GET['$orderby'] : '',
 	'filter' => isset($_GET['$filter']) ? $_GET['$filter'] : '',
 	'searchQuery' => isset($_GET['searchterm']) ? trim($_GET['searchterm'], '\'') : '',
+	'top' => isset($_GET['$top']) ? $_GET['$top'] : '',
+	'offset' => isset($_GET['$skip']) ? $_GET['$skip'] : ''
 ]);
 $feed = new FeedWriter('Search');
 $feed->writeToOutput($results);


### PR DESCRIPTION
Added pagination to the searchPackages function by adding LIMIT and OFFSET to the database call.  This stops clients from receiving a list of all packages when calling the search and, certainly within Visual Studio, just causing the list to keep repeating as the user scrolls down.

This is a fix for issue #27 