### PR TITLE
Added user configurable sort order for search results

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -7,8 +7,10 @@ class Config {
 	public static $dbPassword;
 	public static $apiKey;
 	public static $packageDir;
+	public static $defaultSortOrder;
 }
 
 Config::$dbName = 'sqlite:../db/packages.sqlite3';
 Config::$packageDir = __DIR__ . '/../packagefiles/';
 Config::$apiKey = 'ChangeThisKey';
+Config::$defaultSortOrder = 'DownloadCount desc, Id';

--- a/inc/db.php
+++ b/inc/db.php
@@ -155,7 +155,7 @@ class DB {
 	private static function parseOrderBy($order_by) {
 		$valid_sort_columns = [
 			'downloadcount' => 'packages.DownloadCount',
-			'id' => 'packages.PackageId',
+			'id' => 'LOWER(packages.PackageId)',
 			'published' => 'versions.Created',
 		];
 		$columns = explode(',', $order_by);

--- a/inc/db.php
+++ b/inc/db.php
@@ -72,7 +72,7 @@ class DB {
 
 		// Defaults
 		if (empty($params['orderBy'])) {
-			$params['orderBy'] = 'DownloadCount desc, Id';
+			$params['orderBy'] = Config::$defaultSortOrder;
 		}
 
 		if (!$params['includePrerelease']) {


### PR DESCRIPTION
Users can change the Config::$defaultSortOrder to whatever order they require, be it the current default of DownloadCount and Id or just alphabetic (Id).

Also the sort order of the PackageId is now case-insensitive