### PR TITLE
Added 'COLLATE NOCASE' to findByID

### DIFF
--- a/inc/db.php
+++ b/inc/db.php
@@ -158,7 +158,7 @@ class DB {
 	 * all versions.
 	 */
 	public static function findByID($id, $version = null) {
-		$where = 'packages.PackageId = :id';
+		$where = 'packages.PackageId = :id COLLATE NOCASE';
 		$params = ['id' => $id];
 		if (!empty($version)) {
 			$where .= ' AND versions.Version = :version';


### PR DESCRIPTION
Using simple-nuget-ser as nuget server (running on the default SQLite in docker) and doing a "dotnet tool install ..." the install woud fail because the package could not be found.

I traced it down to "dotnet tool install" trying to find an all lowercase version of the package. I think the nuget api is supposed to be case IN-sensitive, so I guess this is a bug in simple-nuget-server.

Adding "COLLATE NOCASE" to the lookup makes "dotnet tool install" happy.